### PR TITLE
Use "per_page=100" query parameter

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -50,7 +50,7 @@ function getUserRepos() {
      });
     var repoNames = [];
 
-    var url = apiRoot + "users/" + user + "/repos";
+    var url = apiRoot + "users/" + user + "/repos?per_page=100";
     $.getJSON(url, function(data) {
         $.each(data, function(index, item) {
             repoNames.push(item.name);


### PR DESCRIPTION
When searching for user's repositories - append "per_page=100" query parameter to get a better overview on available repositories, otherwise only a default number is returned (I guess around 30). For instance without it - a very popular "antrirez/redis" does not show up in lookup list. This is not an ideal solution, but uses the maximum available value for "per_page" without introducing real paging/querying for repositories in some other way.