### PR TITLE
Use correct casing for GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Github Release Stats</title>
+    <title>GitHub Release Stats</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="Get the latest release stats like download counts, release dates, author on any Github project">
-    <meta name="keywords" content="Github, release, download, count">
+    <meta name="description" content="Get the latest release stats like download counts, release dates, author on any GitHub project">
+    <meta name="keywords" content="GitHub, release, download, count">
     <link rel="icon" href="img/favicon.ico">
     <link href="https://fonts.googleapis.com/css?family=Roboto|Roboto+Mono" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="third-party/bootstrap/css/bootstrap.min.css">
@@ -22,7 +22,7 @@
                 </button>
                 <a class="navbar-brand" href=".">
                     <span class="glyphicon glyphicon-stats"></span>&nbsp;
-                    Github Release Stats
+                    GitHub Release Stats
                 </a>
             </div>
             <div class="collapse navbar-collapse" id="main-navbar">
@@ -30,7 +30,7 @@
                     <li>
                         <a href="https://github.com/Somsubhra/github-release-stats" target="_blank">
                             <span class="glyphicon glyphicon-eye-open"></span>&nbsp;
-                            View project on Github
+                            View project on GitHub
                         </a>
                     </li>
                 </ul>
@@ -43,7 +43,7 @@
                 <h1>Enter project details...</h1>
                 <div class="form form-inline">
                     <div class="form-group">
-                        <input type="text" class="form-control" id="username" placeholder="Github username">
+                        <input type="text" class="form-control" id="username" placeholder="GitHub username">
                     </div>
                     <div class="form-group">
                         <input type="text" class="form-control" id="repository" placeholder="Repository name">
@@ -53,7 +53,7 @@
             </div>
         </div>
         <div class="row" id="description">
-            <h1>...and get the latest release stats like download counts, release dates, authors for any Github project.</h1>
+            <h1>...and get the latest release stats like download counts, release dates, authors for any GitHub project.</h1>
         </div>
         <div class="row" id="title">
             <h1><span class="username"></span>/<span class="repository"></span></h1>


### PR DESCRIPTION
Minor update to use the proper casing for GitHub's name.