### PR TITLE
updated code css selector to be more responsive

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -19,7 +19,6 @@ code {
 	    background-color: rgba(127, 140, 141, 0.1);
 	    color: inherit;
 	    white-space: nowrap;
-	    white-space: nowrap;
 	    text-overflow: ellipsis;
 	    width: 300px;
 	    display: block;

--- a/css/main.css
+++ b/css/main.css
@@ -13,6 +13,20 @@ code {
     white-space: nowrap;
 }
 
+@media only screen and (max-width: 1024px) {
+	code {
+	    font-family: 'Roboto Mono', monospace;
+	    background-color: rgba(127, 140, 141, 0.1);
+	    color: inherit;
+	    white-space: nowrap;
+	    white-space: nowrap;
+	    text-overflow: ellipsis;
+	    width: 300px;
+	    display: block;
+	    overflow: hidden;
+	}
+}
+
 .form-group {
     width: 100%;
 }


### PR DESCRIPTION
**Changes:**
Fixed an issue where release asset file names that are too long will cause the _code_ element to overflow beyond its parent element and break responsive UI globally.

**Before:**
![before](https://github.com/user-attachments/assets/3c70f671-2244-4310-8b25-ebe6979effac)


**After:**
![after](https://github.com/user-attachments/assets/2e73405b-0fd3-4f46-8a5a-6189c85ffb84)
